### PR TITLE
Fix CSS bug when a switcher is ON by default

### DIFF
--- a/angular-toggle-switch.js
+++ b/angular-toggle-switch.js
@@ -5,7 +5,7 @@ angular.module('toggle-switch', ['ng']).directive('toggleSwitch', function() {
     scope: {
       model: '='
     },
-    template: '<div class="switch" ng-click="toggle()"><div class="switch-animate switch-off" ng-class="{\'switch-off\': !model, \'switch-on\': model}"><span class="switch-left">On</span><span class="knob">&nbsp;</span><span class="switch-right">Off</span></div></div>',
+    template: '<div class="switch" ng-click="toggle()"><div class="switch-animate" ng-class="{\'switch-off\': !model, \'switch-on\': model}"><span class="switch-left">On</span><span class="knob">&nbsp;</span><span class="switch-right">Off</span></div></div>',
     link: function($scope, element, attrs) {
       if ($scope.model == null) {
         $scope.model = false;


### PR DESCRIPTION
If you load a switcher with a `true` model, the switcher has both CSS class `switch-off` and `switch-on` and the class 'switch-on' isn't render. Remove `switch-off` class fix the issue.
