### PR TITLE
Add css to bower's main property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,10 @@
 {
   "name": "angular-toggle-switch",
   "version": "0.3.0",
-  "main": "angular-toggle-switch.min.js",
+  "main": [
+    "angular-toggle-switch.js",
+    "angular-toggle-switch.css"
+  ],
   "homepage": "http://cgarvis.github.io/angular-toggle-switch/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
angular-toggle-switch isn't usable without some styling, which the main
stylesheet provides. A build tool like grunt-bower-install can automatically
inject the file into `index.html` (say).

The bootstrap theme is probably best left off, but perhaps a note should be
added to the readme?

Also switched to non-minified js as per the [bower spec](https://github.com/bower/bower.json-spec/blob/d8e7299a94b76171135b066ceb570fb4df4caa4c/README.md#main).
