### PR TITLE
Add ability to use different variable type for ngModel

### DIFF
--- a/angular-toggle-switch.js
+++ b/angular-toggle-switch.js
@@ -36,8 +36,6 @@ angular.module('toggle-switch', ['ng']).directive('toggleSwitch', function () {
       });
 
       ngModelCtrl.$formatters.push(function(modelValue){
-        //console.log('formatters', modelValue);
-        //return modelValue;
         if(attrs.onValue === modelValue) {
           return true;
         }
@@ -45,7 +43,6 @@ angular.module('toggle-switch', ['ng']).directive('toggleSwitch', function () {
       });
 
       ngModelCtrl.$parsers.push(function(viewValue){
-        //console.log('parsers', viewValue);
         if(viewValue) {
           return attrs.onValue;
         }


### PR DESCRIPTION
Usage:
Default:

```
<toggle-switch ng-model="switchStatus1"><toggle-switch>
```

For number:

```
<toggle-switch ng-model="switchStatus2" on-value="1" off-value="2" on-label="1" off-label="2"><toggle-switch>
```

For string:

```
<toggle-switch ng-model="switchStatus3" on-value="O" off-value="C" on-label="Open" off-label="Close"><toggle-switch>
```
