### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "name": "Chris Garvis",
     "url": "http://chrisgarvis.com"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com:cgarvis/angular-toggle-switch.git"
+  },
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
prevents NPM "No repository field" warnings