### PR TITLE
After space-bar toggle, stop scrolling of page

### DIFF
--- a/angular-toggle-switch.js
+++ b/angular-toggle-switch.js
@@ -52,6 +52,7 @@
           var key = e.which ? e.which : e.keyCode;
           if (key === KEY_SPACE) {
             scope.$apply(scope.toggle);
+            $event.preventDefault();
           }
         });
 


### PR DESCRIPTION
Issue is, on a key press (space-bar) event, a long page will scroll down. Fix, marks the event as having been handled (stop bubbling up the event to the page).